### PR TITLE
Run prettier as part of `next lint`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals", "prettier"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "typescript": "^5.1.6"
       },
       "devDependencies": {
+        "eslint-config-prettier": "^9.0.0",
         "prettier": "^3.0.0"
       }
     },
@@ -1404,6 +1405,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -5200,6 +5213,13 @@
         "eslint-plugin-react": "^7.31.7",
         "eslint-plugin-react-hooks": "5.0.0-canary-7118f5dd7-20230705"
       }
+    },
+    "eslint-config-prettier": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "^5.1.6"
   },
   "devDependencies": {
+    "eslint-config-prettier": "^9.0.0",
     "prettier": "^3.0.0"
   }
 }

--- a/src/components/common/PostCard/index.tsx
+++ b/src/components/common/PostCard/index.tsx
@@ -20,7 +20,7 @@ const PostCard = () => {
         </aside>
       </section>
       <header>
-        <h1 className="mt-3 text-2xl font-bold">Post title is very long and big and tries to be a bit too overly descriptive but I'll allow it</h1>
+        <h1 className="mt-3 text-2xl font-bold">{"Post title is very long and big and tries to be a bit too overly descriptive but I'll allow it"}</h1>
       </header>
       <footer className="mt-5 flex flex-row">
         <div className="flex gap-x-3">


### PR DESCRIPTION
Also fixes an existing lint error.

Btw, do you want `next lint` to be run as a git pre-commit hook (https://nextjs.org/docs/app/building-your-application/configuring/eslint#lint-staged)? For sure it should be run in a GitHub workflow as well, but it could be convenient to have it run locally for all contributors.