### PR TITLE
Use the strict version to omit unnecessary words

### DIFF
--- a/src/components/common/PostCard/index.tsx
+++ b/src/components/common/PostCard/index.tsx
@@ -5,7 +5,7 @@ import {
 } from '@heroicons/react/24/solid';
 import { BookmarkIcon as OutlineBookmarkIcon } from '@heroicons/react/24/outline';
 import { PostView } from 'lemmy-js-client';
-import { formatDistanceToNow } from 'date-fns';
+import { formatDistanceToNowStrict } from 'date-fns';
 import { getHostFromActorId } from '@utils/getHostFromActorId';
 import { compactNumberFormatter } from '@utils/compactNumberFormatter';
 
@@ -36,7 +36,7 @@ export const PostCard = (props: Props) => {
             </p>
             <p>&#8226;</p>
             <p>
-              {formatDistanceToNow(new Date(props.postView.post.published), {
+              {formatDistanceToNowStrict(new Date(props.postView.post.published), {
                 addSuffix: true,
               })}
             </p>


### PR DESCRIPTION
This area already takes up a lot of space, and is especially cramped in mobile view. Omitting some of the fluff words may help.

https://date-fns.org/v2.30.0/docs/formatDistanceToNowStrict